### PR TITLE
Windows: make get_key cross-platform with msvcrt fallback

### DIFF
--- a/bardolph/controller/get_key.py
+++ b/bardolph/controller/get_key.py
@@ -1,13 +1,33 @@
+# bardolph/controller/get_key.py
 import sys
-import termios
-import tty
 
-def getch():
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return ch
+if sys.platform.startswith("win"):
+    import msvcrt
+
+    def getch(timeout=None):
+        if timeout is None:
+            ch = msvcrt.getch()
+            return ch.decode("utf-8", errors="ignore")
+        # simple timed poll
+        import time
+        start = time.time()
+        while True:
+            if msvcrt.kbhit():
+                ch = msvcrt.getch()
+                return ch.decode("utf-8", errors="ignore")
+            if time.time() - start >= float(timeout):
+                return ""
+else:
+    import termios, tty, select
+
+    def getch(timeout=None):
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            if timeout is None:
+                return sys.stdin.read(1)
+            r, _, _ = select.select([sys.stdin], [], [], float(timeout))
+            return sys.stdin.read(1) if r else ""
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)

--- a/bardolph/controller/get_key.py
+++ b/bardolph/controller/get_key.py
@@ -1,33 +1,31 @@
-# bardolph/controller/get_key.py
 import sys
 
-if sys.platform.startswith("win"):
+if sys.platform == "win32":
     import msvcrt
 
-    def getch(timeout=None):
-        if timeout is None:
-            ch = msvcrt.getch()
-            return ch.decode("utf-8", errors="ignore")
-        # simple timed poll
-        import time
-        start = time.time()
-        while True:
-            if msvcrt.kbhit():
-                ch = msvcrt.getch()
-                return ch.decode("utf-8", errors="ignore")
-            if time.time() - start >= float(timeout):
-                return ""
-else:
-    import termios, tty, select
+    def getch():
+        ch = msvcrt.getwch()
 
-    def getch(timeout=None):
+        # Handle special keys (arrows, function keys, etc.)
+        if ch in ("\x00", "\xe0"):
+            msvcrt.getwch()
+            return ""
+
+        return ch
+
+else:
+    import termios
+    import tty
+
+    def getch():
         fd = sys.stdin.fileno()
-        old = termios.tcgetattr(fd)
+        old_settings = termios.tcgetattr(fd)
+
         try:
             tty.setraw(fd)
-            if timeout is None:
-                return sys.stdin.read(1)
-            r, _, _ = select.select([sys.stdin], [], [], float(timeout))
-            return sys.stdin.read(1) if r else ""
+            ch = sys.stdin.read(1)
+
         finally:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+        return ch


### PR DESCRIPTION
Problem

On Windows, running lsrun fails because get_key.py imports POSIX-only modules (termios and tty).

Solution

Use msvcrt on Windows while retaining the existing termios/tty implementation on Unix-like systems.

Testing

Windows 11 / Python 3.13

* lscap works correctly
* lsrun executes scripts correctly
* cycle-color.ls runs successfully
* LIFX device discovery and control verified

Please verify no behavior changes on Linux/macOS.